### PR TITLE
Replace REXML with Nokogiri to make traversing errors more easy

### DIFF
--- a/lib/headhunter.rb
+++ b/lib/headhunter.rb
@@ -1,5 +1,6 @@
 require 'headhunter/css_hunter'
 require 'headhunter/css_validator'
+require 'headhunter/local_response'
 require 'headhunter/html_validator'
 require 'headhunter/rails'
 require 'headhunter/runner'

--- a/lib/headhunter/local_response.rb
+++ b/lib/headhunter/local_response.rb
@@ -1,11 +1,11 @@
-require 'rexml/document'
+require 'nokogiri/xml'
 
 module Headhunter
   class LocalResponse
     attr_reader :body
 
     def initialize(body)
-      @body = body
+      @body = Nokogiri::XML(body)
       @headers = {'x-w3c-validator-status' => valid?}
     end
 
@@ -14,7 +14,19 @@ module Headhunter
     end
 
     def valid?
-      REXML::Document.new(@body).root.each_element('//m:validity') { |e| return e.text == 'true' }
+      @body.css('validity') == 'true'
+    end
+
+    def errors
+      @body.css('errors error').map do |error|
+        { line: error.css('line').text.strip.to_i,
+          errortype: error.css('errortype').text.strip,
+          context: error.css('context').text.strip,
+          errorsubtype: error.css('errorsubtype').text.strip,
+          skippedstring: error.css('skippedstring').text.strip,
+          message: error.css('message').text.strip[0..-3]
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
REXML is very painful to traverse. To be able to print out more useful outputs later, we switch to Nokogiri. This makes sense because Nokogiri is required by Capybara and consorts anyways.
